### PR TITLE
Clear connection pool so that an actual connection is created always

### DIFF
--- a/src/Dotnet.Microservice/Health/Checks/PostgresqlHealthCheck.cs
+++ b/src/Dotnet.Microservice/Health/Checks/PostgresqlHealthCheck.cs
@@ -15,6 +15,7 @@ namespace Dotnet.Microservice.Health.Checks
             try
             {
                 NpgsqlConnection conn = new NpgsqlConnection(connectionString);
+                NpgsqlConnection.ClearPool(conn);
                 conn.Open();
                 string host = conn.Host;
                 string version = conn.PostgreSqlVersion.ToString();


### PR DESCRIPTION
This fixes the issue with no detecting postgres going down after a successful connection was created.
